### PR TITLE
escape spaces in fonts with multiple words

### DIFF
--- a/lib/ask_awesomely/design.rb
+++ b/lib/ask_awesomely/design.rb
@@ -7,10 +7,10 @@ module AskAwesomely
       Arvo
       Bangers
       Cabin
-      Cabin Condensed
+      Cabin\ Condensed
       Courier
-      Crete Round
-      Dancing Script
+      Crete\ Round
+      Dancing\ Script
       Exo
       Georgia
       Handlee
@@ -21,15 +21,15 @@ module AskAwesomely
       McLaren
       Monsterrat
       Nixie
-      Old Standard TT
-      Open Sans
+      Old\ Standard\ TT
+      Open\ Sans
       Oswald
       Playfair
       Quicksand
       Raleway
       Signika
       Sniglet
-      Source Sans Pro
+      Source\ Sans\ Pro
       Vollkorn
     ]
 


### PR DESCRIPTION
Previously, fonts with multiple words like "Open Sans" or "Source Sans Pro" were being added to the `VALID_WORDS` array as ["Open", "Sans"] due to the way the `%w()` function handles spaces. As a result, "Open Sans" would not be viewed as a valid font.

I solved this by escaping the spaces in the array.