### PR TITLE
make embed_as work

### DIFF
--- a/lib/ask_awesomely/typeform.rb
+++ b/lib/ask_awesomely/typeform.rb
@@ -24,7 +24,7 @@ module AskAwesomely
     end
 
     def embed_as(type, options = {})
-      Embeddable.new(type, options).render(self, options)
+      Embeddable.new(type).render(self, options)
     end
 
     def update_with_api_response(response)


### PR DESCRIPTION
Embeddables' init expects the type only to be passed not the type and options