### PR TITLE
Fixed statement field quotation marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A block of text that isn't a question and requires no answer.
 field :statement do
   say "what you want to say"
   button_text "Okay, next question"
-  show_quotation_marks
+  no_quotation_marks
 end
 ```
 

--- a/lib/ask_awesomely/field/statement.rb
+++ b/lib/ask_awesomely/field/statement.rb
@@ -5,8 +5,8 @@ module AskAwesomely
       super
     end
 
-    def show_quotation_marks
-      @state.has_marks = true
+    def no_quotation_marks
+      @state.hide_marks = true
     end
 
     def button_text(text)


### PR DESCRIPTION
Had a bug when using show_quotation_marks (400 response code). Fixed to
conform to the API doc http://docs.typeform.io/docs/statementfield
